### PR TITLE
User can have a session that allows them to stay login for a longer period of time

### DIFF
--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,0 +1,16 @@
+FROM postgres:17-alpine
+
+# Install pg_cron from the Alpine repository
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache postgresql-pg_cron --repository=https://dl-cdn.alpinelinux.org/alpine/v3.18/community
+
+    # Adjust paths for PostgreSQL 17
+RUN ln -s /usr/lib/postgresql17/pg_cron.so /usr/local/lib/postgresql/pg_cron.so && \
+    ln -s /usr/share/postgresql17/extension/pg_cron* /usr/local/share/postgresql/extension
+
+# Set up cron and PostgreSQL configurations
+COPY init-db/pg-cron.sh /docker-entrypoint-initdb.d/pg-cron.sh
+
+RUN chmod +x /docker-entrypoint-initdb.d/pg-cron.sh
+

--- a/auth.oai.yaml
+++ b/auth.oai.yaml
@@ -464,6 +464,10 @@ paths:
       responses:
         "200":
           description: The access token is valid, and the user is authenticated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserData"
           # TODO: add roles to the microservices to allow only certain user to access to some functionalities
           # 
           # content:
@@ -595,6 +599,19 @@ components:
           type: string
       example:
         token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSJ9.Tm__Ymx-4FgWsd1zdb-WxMPojmK4Vmpx"
+    UserData:
+      type: object
+      properties:
+        email:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+      example:
+        email: "john.doe@gmail.com"
+        firstName: "John"
+        lastName: "Doe"
     UserPassword:
       type: object
       properties:

--- a/crypto.go
+++ b/crypto.go
@@ -44,12 +44,12 @@ func GenerateJWT(data map[string]interface{}, secret string) (string, error) {
 }
 
 // GenerateAccessToken generates an access token with user-specific data
-func GenerateAccessToken(userID string, roles []string, secret string) (string, error) {
+func GenerateAccessToken(userID string, roles []string, secret string, validity time.Duration) (string, error) {
 	// Define claims
 	claims := map[string]interface{}{
 		"user_id": userID,
 		"roles":   roles,
-		"exp":     time.Now().Add(time.Hour).Unix(), // Token expires in 1 hour
+		"exp":     time.Now().Add(validity).Unix(), // Token expires in 1 hour
 		"iat":     time.Now().Unix(),
 		"iss":     "betalink-auth",
 		"aud":     "betalink",
@@ -61,6 +61,45 @@ func GenerateAccessToken(userID string, roles []string, secret string) (string, 
 
 // ValidateAccessToken validates an access token
 func ValidateAccessToken(token, secret string) (jwt.MapClaims, error) {
+	// Parse the token
+	parsedToken, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
+		return []byte(secret), nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not parse token: %w", err)
+	}
+
+	// Check if the token is valid
+	if !parsedToken.Valid {
+		return nil, fmt.Errorf("token is invalid")
+	}
+
+	// Extract the claims
+	claims, ok := parsedToken.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("could not extract claims from token")
+	}
+
+	return claims, nil
+}
+
+// GenerateRefreshToken generates a refresh token
+func GenerateRefreshToken(sessionID string, createdAt, expiresAt time.Time, secret string) (string, error) {
+	// Define claims
+	claims := map[string]interface{}{
+		"session_id": sessionID,
+		"exp":        expiresAt.Unix(),
+		"iat":        createdAt.Unix(),
+		"iss":        "betalink-auth",
+		"aud":        "betalink",
+	}
+
+	// Generate the JWT using the helper function
+	return GenerateJWT(claims, secret)
+}
+
+// ValidateRefreshToken validates a refresh token
+func ValidateRefreshToken(token, secret string) (jwt.MapClaims, error) {
 	// Parse the token
 	parsedToken, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
 		return []byte(secret), nil

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -45,7 +45,7 @@ func TestGenerateAccessToken(t *testing.T) {
 	roles := []string{"admin", "user"}
 	secret := "mysecret"
 
-	token, err := betalinkauth.GenerateAccessToken(userID, roles, secret)
+	token, err := betalinkauth.GenerateAccessToken(userID, roles, secret, time.Hour)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, token)
 
@@ -71,7 +71,7 @@ func TestValidateAccessToken(t *testing.T) {
 	roles := []string{"admin", "user"}
 	secret := "mysecret"
 
-	token, err := betalinkauth.GenerateAccessToken(userID, roles, secret)
+	token, err := betalinkauth.GenerateAccessToken(userID, roles, secret, time.Hour)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, token)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,8 @@
 services:
   betalink-auth-db:
-    image: postgres:17-alpine
+    build:
+      context: .
+      dockerfile: Dockerfile.db
     environment:
       POSTGRES_USER: betalinkauth
       POSTGRES_PASSWORD: betalinkauth

--- a/errors.go
+++ b/errors.go
@@ -21,3 +21,10 @@ type ValidationError struct {
 func (e *ValidationError) Error() string {
 	return e.Message
 }
+
+var (
+	// ExpiredTokenError is an error that represents an expired token
+	ExpiredTokenError = &ValidationError{
+		Message: "Token has expired",
+	}
+)

--- a/init-db/pg-cron.sh
+++ b/init-db/pg-cron.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "Running pg-cron initialization" > /tmp/pg-cron-init.log
+
+dbname="$POSTGRES_DB"
+customconf=/var/lib/postgresql/data/custom-conf.conf
+echo "" > $customconf
+echo "shared_preload_libraries = 'pg_cron'" >> $customconf
+echo "cron.database_name = '$dbname'" >> $customconf
+chown postgres $customconf
+chgrp postgres $customconf
+
+# include custom config from main config
+conf=/var/lib/postgresql/data/postgresql.conf
+found=$(grep "include = '$customconf'" $conf)
+if [ -z "$found" ]; then
+  echo "include = '$customconf'" >> $conf
+fi
+
+echo "Completed pg-cron initialization" >> /tmp/pg-cron-init.log

--- a/insomnia-requests.yaml
+++ b/insomnia-requests.yaml
@@ -1,0 +1,182 @@
+_type: export
+__export_format: 4
+__export_date: 2025-01-16T14:58:55.987Z
+__export_source: insomnia.desktop.app:v10.0.0
+resources:
+  - _id: req_580a600725784d9c965ebf45acd9d067
+    parentId: fld_1dcc02f0ef40493faa966e54c0eb44b4
+    modified: 1737018736314
+    created: 1737017946575
+    url: http://localhost:8080/register
+    name: register-user
+    description: ""
+    method: POST
+    body:
+      mimeType: application/json
+      text: |-
+        {
+          "email": "john.doe@gmail.com",
+          "password": "#drfR%6!",
+        	"firstname": "John",
+        	"lastname": "Doe"
+        }
+    parameters: []
+    headers:
+      - name: Content-Type
+        value: application/json
+      - name: User-Agent
+        value: insomnia/10.0.0
+    authentication:
+      type: none
+    metaSortKey: -1737017949054
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: fld_1dcc02f0ef40493faa966e54c0eb44b4
+    parentId: wrk_scratchpad
+    modified: 1737017942808
+    created: 1737017942808
+    name: betalink-auth
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1737017942808
+    _type: request_group
+  - _id: wrk_scratchpad
+    parentId: null
+    modified: 1737017913333
+    created: 1737017913333
+    name: Scratch Pad
+    description: ""
+    scope: collection
+    _type: workspace
+  - _id: req_19176cf6853143f085686d665b761466
+    parentId: fld_1dcc02f0ef40493faa966e54c0eb44b4
+    modified: 1737018790060
+    created: 1737018748379
+    url: http://localhost:8080/login
+    name: login-user
+    description: ""
+    method: POST
+    body:
+      mimeType: application/json
+      text: |-
+        {
+        	"email": "john.doe@gmail.com",
+          "password": "#drfR%6!"
+        }
+    parameters: []
+    headers:
+      - name: Content-Type
+        value: application/json
+      - name: User-Agent
+        value: insomnia/10.0.0
+    authentication: {}
+    metaSortKey: -1737017948954
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_a2d4fbdea6d94045816799ff30d8786a
+    parentId: fld_1dcc02f0ef40493faa966e54c0eb44b4
+    modified: 1737018957366
+    created: 1737018911939
+    url: http://localhost:8080/token/validate
+    name: validate-access-token
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers:
+      - name: User-Agent
+        value: insomnia/10.0.0
+        id: pair_828424938aaf40068311bd43c6478267
+      - id: pair_4285b0876615434fae6420559aa712b5
+        name: Authorization
+        value: "{{ _.auth_token }}"
+        description: ""
+        disabled: false
+    authentication: {}
+    metaSortKey: -1737017948854
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_2c0641bc0c1a4ee5be2212020343594e
+    parentId: fld_1dcc02f0ef40493faa966e54c0eb44b4
+    modified: 1737037778087
+    created: 1737037738827
+    url: http://localhost:8080/token/refresh
+    name: refresh-access-token
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers:
+      - name: User-Agent
+        value: insomnia/10.0.0
+        id: pair_32c90a00c64b4b8690038a562537f2a9
+      - id: pair_6ede9459d3b440388cf646677b1c161b
+        name: Authorization
+        value: "{{ _.auth_token }}"
+        description: ""
+        disabled: false
+    authentication: {}
+    metaSortKey: -1737017948754
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: env_99d30891da4bdcebc63947a8fc17f076de878684
+    parentId: wrk_scratchpad
+    modified: 1737018901898
+    created: 1737017921480
+    name: Base Environment
+    data:
+      auth_token: "{% response 'header', 'req_19176cf6853143f085686d665b761466',
+        'b64::QXV0aG9yaXphdGlvbg==::46b', 'never', 60 %}"
+    dataPropertyOrder:
+      "&":
+        - auth_token
+    color: null
+    isPrivate: false
+    metaSortKey: 1737017921480
+    _type: environment
+  - _id: jar_99d30891da4bdcebc63947a8fc17f076de878684
+    parentId: wrk_scratchpad
+    modified: 1737037885865
+    created: 1737017921525
+    name: Default Jar
+    cookies:
+      - key: refresh_token
+        value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJiZXRhbGluayIsImV4cCI6MTczNzEyNDI4NSwiaWF0IjoxNzM3MDM3ODg1LCJpc3MiOiJiZXRhbGluay1hdXRoIiwic2Vzc2lvbl9pZCI6ImMwYjMwYWI2LTFjODItNDc0My1hNGUxLTUzZWY3MmEwNzk0OCJ9.EHcXdvqZ2dLFMvvRADUvOVSndAG1BeVuDjZGqZpzpZg
+        maxAge: 3600
+        domain: localhost
+        path: /
+        httpOnly: true
+        hostOnly: false
+        creation: 2025-01-16T09:13:12.038Z
+        lastAccessed: 2025-01-16T14:31:25.865Z
+        id: 68b51f59-b473-45eb-a72f-689ed39205a1
+    _type: cookie_jar

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// UserData represents the user information retrieved from the auth server
+type UserData struct {
+	UserID    string
+	FirstName string
+	LastName  string
+}
+
+// AuthRequired is a gin middleware that checks if the user is authenticated.
+// If the user is not authenticated, it will return a 401 Unauthorized status.
+// Otherwise, it will store the user information in the context and call
+// the next handler.
+func AuthRequired(authServerURL string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Extract the Authorization header
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authorization header is required"})
+			c.Abort()
+			return
+		}
+
+		// Validate the format of the Authorization header
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid Authorization header format"})
+			c.Abort()
+			return
+		}
+
+		req, err := http.NewRequest("GET", authServerURL, nil)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+			c.Abort()
+			return
+		}
+		// Forward the Authorization header to the auth server
+		req.Header.Set("Authorization", authHeader)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil || resp.StatusCode != http.StatusOK {
+			message := "Unauthorized"
+			if resp != nil {
+				body, _ := io.ReadAll(resp.Body)
+				message = fmt.Sprintf("Auth server error: %s", bytes.TrimSpace(body))
+				resp.Body.Close()
+			}
+			c.JSON(http.StatusUnauthorized, gin.H{"error": message})
+			c.Abort()
+			return
+		}
+
+		var user UserData
+		if err := json.NewDecoder(resp.Body).Decode(&user); err == nil {
+			c.Set("user", user) // Store user info in the context
+		}
+		resp.Body.Close()
+
+		c.Next()
+	}
+}

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -1,0 +1,93 @@
+package middleware_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/BragdonD/betalink-auth/middleware"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// Mock data
+var validUser = middleware.UserData{
+	UserID:    "12345",
+	FirstName: "John",
+	LastName:  "Doe",
+}
+
+func TestAuthRequired(t *testing.T) {
+	// Mock the authentication server
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "Bearer valid-token" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(validUser)
+		} else {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		}
+	}))
+	defer authServer.Close()
+
+	tests := []struct {
+		name         string
+		authHeader   string
+		expectedCode int
+		expectedBody string
+	}{
+		{
+			name:         "Valid token",
+			authHeader:   "Bearer valid-token",
+			expectedCode: http.StatusOK,
+			expectedBody: "",
+		},
+		{
+			name:         "Missing token",
+			authHeader:   "",
+			expectedCode: http.StatusUnauthorized,
+			expectedBody: `{"error":"Authorization header is required"}`,
+		},
+		{
+			name:         "Invalid token format",
+			authHeader:   "Basic invalid-token",
+			expectedCode: http.StatusUnauthorized,
+			expectedBody: `{"error":"Invalid Authorization header format"}`,
+		},
+		{
+			name:         "Unauthorized token",
+			authHeader:   "Bearer invalid-token",
+			expectedCode: http.StatusUnauthorized,
+			expectedBody: `{"error":"Auth server error: Unauthorized"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up Gin
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+			r.Use(middleware.AuthRequired(authServer.URL))
+			r.GET("/test", func(c *gin.Context) {
+				c.Status(http.StatusOK)
+			})
+
+			// Create a test request
+			req := httptest.NewRequest("GET", "/test", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			w := httptest.NewRecorder()
+
+			// Serve the request
+			r.ServeHTTP(w, req)
+
+			// Assertions
+			assert.Equal(t, tt.expectedCode, w.Code)
+			if tt.expectedBody != "" {
+				assert.JSONEq(t, tt.expectedBody, w.Body.String())
+			}
+		})
+	}
+}

--- a/migrations/20250113070416_create_session_table.sql
+++ b/migrations/20250113070416_create_session_table.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+-- CREATE EXTENSION IF NOT EXISTS "pg_cron";
+
+CREATE TABLE Sessions (
+    session_token TEXT NOT NULL PRIMARY KEY,
+    user_id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES Users(user_id)
+);
+
+-- Delete expired sessions every 20 minutes
+-- SELECT cron.schedule('session-cleanup', '20 * * * *', 'DELETE FROM Sessions WHERE expires_at < NOW()');

--- a/migrations/20250113092128_update_sessions_table.sql
+++ b/migrations/20250113092128_update_sessions_table.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+
+ALTER TABLE Sessions
+RENAME COLUMN session_token TO session_id;
+
+ALTER TABLE Sessions
+ALTER COLUMN session_id SET DATA TYPE UUID USING session_id::UUID;
+
+ALTER TABLE Sessions
+ALTER COLUMN session_id SET DEFAULT uuid_generate_v4();

--- a/models.go
+++ b/models.go
@@ -32,6 +32,14 @@ type Passwordrecovery struct {
 	Used          bool
 }
 
+type Session struct {
+	SessionID pgtype.UUID
+	UserID    pgtype.UUID
+	CreatedAt pgtype.Timestamptz
+	UpdatedAt pgtype.Timestamptz
+	ExpiresAt pgtype.Timestamptz
+}
+
 type User struct {
 	UserID    pgtype.UUID
 	FirstName string

--- a/query.sql
+++ b/query.sql
@@ -15,3 +15,15 @@ SELECT user_id, email, passwordHash, passwordSalt, hashAlgorithm FROM UsersLogin
 
 -- name: GetUserById :one
 SELECT user_id, first_name, last_name FROM Users WHERE user_id = $1;
+
+-- name: CreateSession :one
+INSERT INTO Sessions (user_id, created_at, updated_at, expires_at) VALUES ($1, $2, $3, $4) RETURNING session_id;
+
+-- name: GetSessionById :one
+SELECT session_id, user_id, created_at, updated_at, expires_at FROM Sessions WHERE session_id = $1;
+
+-- name: Test_UpdateSessionExpiresAt :exec
+UPDATE Sessions SET expires_at = $1 WHERE session_id = $2;
+
+-- name: DeleteSession :exec
+DELETE FROM Sessions WHERE session_id = $1;


### PR DESCRIPTION
## Features

- User creates a session on successful login
- User can refresh his access token using his access token
- Add a gin auth middleware that can be used by other µ-service to check if the user is authenticated. If he is, his id, firstname and lastname are added to the gin context.

## Fixes 

- Small fix on the error type in the email check function
- Remove pg_cron until we find a better solution due to conflict in test
